### PR TITLE
add url validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ The default behavior is not to strip any query parameters.
 This setting is useful when the validated requests are proxied to some upstream server (using proxy_pass) - 
 it can be used to remove the token from the upstream request
 
+#### akamai_token_validate_url
+* **syntax**: `akamai_token_validate_url on|off`
+* **default**: `off`
+* **context**: `http`, `server`, `location`
+
+This setting toggles performing url validation if no `acl` is present in the token data.
+URL validation adds the request URI to end of the signed data of the HMAC which can be useful when creating
+a signed URL for one resource.
+
 ### Sample configuration
 The following configuration requires a token parameter named `token`, either as a query string parameter or as a cookie:
 ```

--- a/README.md
+++ b/README.md
@@ -45,15 +45,6 @@ The default behavior is not to strip any query parameters.
 This setting is useful when the validated requests are proxied to some upstream server (using proxy_pass) - 
 it can be used to remove the token from the upstream request
 
-#### akamai_token_validate_url
-* **syntax**: `akamai_token_validate_url on|off`
-* **default**: `off`
-* **context**: `http`, `server`, `location`
-
-This setting toggles performing url validation if no `acl` is present in the token data.
-URL validation adds the request URI to end of the signed data of the HMAC which can be useful when creating
-a signed URL for one resource.
-
 ### Sample configuration
 The following configuration requires a token parameter named `token`, either as a query string parameter or as a cookie:
 ```

--- a/ngx_http_akamai_token_validate_module.c
+++ b/ngx_http_akamai_token_validate_module.c
@@ -286,7 +286,6 @@ ngx_http_akamai_token_validate(ngx_http_request_t *r, ngx_str_t* token, ngx_str_
 	HMAC_CTX_init(hmac);
 #endif
 	HMAC_Init_ex(hmac, key->data, key->len, EVP_sha256(), NULL);
-
 	HMAC_Update(hmac, parsed_token.signed_part.data, parsed_token.signed_part.len);
 
 	// If no acl is defined include the url into the signed data
@@ -302,8 +301,7 @@ ngx_http_akamai_token_validate(ngx_http_request_t *r, ngx_str_t* token, ngx_str_
 	HMAC_CTX_cleanup(hmac);
 #endif
 	hash_hex_len = ngx_hex_dump(hash_hex, hash, hash_len) - hash_hex;
-
-
+	
 	if (hash_hex_len != parsed_token.hmac.len ||
 		ngx_memcmp(hash_hex, parsed_token.hmac.data, hash_hex_len) != 0)
 	{
@@ -545,7 +543,6 @@ ngx_http_akamai_token_validate_merge_loc_conf(ngx_conf_t *cf, void *parent, void
 	}
 	ngx_conf_merge_str_value(conf->key, prev->key, "");
 	ngx_conf_merge_ptr_value(conf->filename_prefixes, prev->filename_prefixes, NULL);
-	ngx_conf_merge_str_value(conf->strip_token, prev->strip_token, "");
 	ngx_conf_merge_str_value(conf->strip_token, prev->strip_token, "");
 	return NGX_CONF_OK;
 }

--- a/ngx_http_akamai_token_validate_module.c
+++ b/ngx_http_akamai_token_validate_module.c
@@ -291,7 +291,7 @@ ngx_http_akamai_token_validate(ngx_http_request_t *r, ngx_str_t* token, ngx_str_
 
 	// If no acl is defined include the url into the signed data
 	if (parsed_token.acl.len == 0) {
-		HMAC_Update(hmac, "~url=", sizeof("~url=") - 1);
+		HMAC_Update(hmac, (u_char*)"~url=", sizeof("~url=") - 1);
 		HMAC_Update(hmac, r->uri.data, r->uri.len);
 	}
 

--- a/ngx_http_akamai_token_validate_module.c
+++ b/ngx_http_akamai_token_validate_module.c
@@ -289,7 +289,8 @@ ngx_http_akamai_token_validate(ngx_http_request_t *r, ngx_str_t* token, ngx_str_
 	HMAC_Update(hmac, parsed_token.signed_part.data, parsed_token.signed_part.len);
 
 	// If no acl is defined include the url into the signed data
-	if (parsed_token.acl.len == 0) {
+	if (parsed_token.acl.len == 0)
+	{
 		HMAC_Update(hmac, (u_char*)"~url=", sizeof("~url=") - 1);
 		HMAC_Update(hmac, r->uri.data, r->uri.len);
 	}


### PR DESCRIPTION
This PR adds support for URL validation for Akamai tokens when no acl is present.
This works by appending "~url=REQUEST_URI" to the signed token data before calculating the HMAC. 

I added a directive `akamai_token_validate_url` to toggle this on or off.

I'm not very proficient in C so the token manipulation may not be best.